### PR TITLE
feat: add retry-aware resource scaling from config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.code-workspace
+.llm-tmp/
 
 tests/evolverMammals/evolverMammals-out*/
 !tests/evolverMammals/evolverMammals-out/evolverMammals.txt

--- a/config-templates/add-outgroup-config-template.yaml
+++ b/config-templates/add-outgroup-config-template.yaml
@@ -86,6 +86,14 @@ use_gpu:
 ##
 ## mem_mb is in MB
 ## time is in minutes
+## Any resource can be either a single value or a YAML list of per-attempt values.
+## If a list is provided, attempt 1 uses the first value, attempt 2 the second, etc.,
+## and attempts beyond the list length reuse the last value.
+## This requires Snakemake retries, e.g. --retries 3.
+## Example:
+##   blast:
+##     mem_mb: [25000, 50000, 100000]
+##     time: [30, 60, 120]
 ##
 ## If using the Harvard cannon cluster profile with --slurm-partition-config <path to cannon-cfg.yml>, partition names can be left blank.
 

--- a/config-templates/config-template.yaml
+++ b/config-templates/config-template.yaml
@@ -61,6 +61,14 @@ use_gpu:
 ##
 ## mem_mb is in MB
 ## time is in minutes
+## Any resource can be either a single value or a YAML list of per-attempt values.
+## If a list is provided, attempt 1 uses the first value, attempt 2 the second, etc.,
+## and attempts beyond the list length reuse the last value.
+## This requires Snakemake retries, e.g. --retries 3.
+## Example:
+##   blast:
+##     mem_mb: [80000, 160000, 200000]
+##     time: [1660, 3320, 6640, 7200]
 ##
 ## If using the Harvard cannon cluster profile with --slurm-partition-config <path to cannon-cfg.yml>, partition names can be left blank.
 

--- a/lib/cactuslib.py
+++ b/lib/cactuslib.py
@@ -791,24 +791,69 @@ def getResources(config, top_level_executor, rule_name, keys=("partition", "mem_
 
     return rule_resources
 
+def _coerceResourceValue(value):
+    if isinstance(value, bool):
+        return value
+
+    try:
+        return int(value);
+    except (TypeError, ValueError):
+        return value;
+
+def _normalizeResourceValue(value, rule_name, resource):
+    if not isinstance(value, list):
+        return _coerceResourceValue(value);
+
+    if not value:
+        raise ValueError(f"Resource schedule for rule '{rule_name}' and resource '{resource}' cannot be empty.");
+
+    return [_coerceResourceValue(item) for item in value];
+
+def _getAttemptScheduledResource(value, rule_name, resource):
+    schedule = tuple(value);
+
+    def getScheduledResource(wildcards, input=None, attempt=1, threads=None, rulename=None):
+        if attempt is None:
+            attempt = 1;
+
+        attempt_index = max(int(attempt) - 1, 0);
+        if attempt_index >= len(schedule):
+            attempt_index = len(schedule) - 1;
+
+        selected_value = schedule[attempt_index];
+        if selected_value is None:
+            raise ValueError(
+                f"Resource schedule for rule '{rule_name}' and resource '{resource}' "
+                f"contains an empty value at attempt {attempt}."
+            );
+
+        return selected_value;
+
+    return getScheduledResource
+
 def getResource(config, top_level_executor, rule_name, resource):
     # Get a specific resource value from the Snakemake config.yaml.
 
     #cactuslib_logger.info(f"Getting resource '{resource}' for rule '{rule_name}' with executor '{top_level_executor}'");
-    rule_val = config.get("rule_resources", {}).get(rule_name, {}).get(resource)
-    default_val = config.get("rule_resources", {}).get("default", {}).get(resource)
-
-    try:
-        rule_val = int(rule_val);
-        default_val = int(default_val);
-    except:
-        pass;
-    # Make sure numerical resources are integers, for consistency with plugin
-        
+    rule_val = _normalizeResourceValue(
+        config.get("rule_resources", {}).get(rule_name, {}).get(resource),
+        rule_name,
+        resource
+    );
+    default_val = _normalizeResourceValue(
+        config.get("rule_resources", {}).get("default", {}).get(resource),
+        "default",
+        resource
+    );
+    # Make sure numerical resources are integers, while allowing optional per-attempt schedules.
 
     if rule_val is not None:
+        if isinstance(rule_val, list):
+            return _getAttemptScheduledResource(rule_val, rule_name, resource);
         return rule_val
     elif default_val is not None:
+        if isinstance(default_val, list):
+            return _getAttemptScheduledResource(default_val, rule_name, resource);
         return default_val
     else:
         if top_level_executor in ["cannon", "slurm"] and resource == "partition":

--- a/tests/evolverMammals/evolverMammals-cfg.yaml
+++ b/tests/evolverMammals/evolverMammals-cfg.yaml
@@ -20,7 +20,7 @@ cactus_path: 3.1.3
 input_file: evolverMammals.txt
 # File containing rooted Newick tree on the first line, and a list of genome files on the following lines.
 
-output_dir: evolverMammals-out8/
+output_dir: evolverMammals-out/
 # The output directory for the snakemake pipeline. This should be the same as the outDir in cactus-prepare.
 # This directory will be created if it doesn't exist.
 
@@ -33,7 +33,7 @@ maf_reference: simHuman_chr6
 tmp_dir: /n/holylfs05/LABS/informatics/Lab/projects/gwct/tmp/evolverMammals/
 # A temporary directory for snakemake and cactus to use. Should have lots of space.
 
-use_gpu: True
+use_gpu: False
 # Whether or not to use the GPU version of cactus.
 # If you don't have a GPU partition, set this to False.
 # Either way, be sure to set the correct values for the partitions and GPUs below.


### PR DESCRIPTION
This PR adds retry-aware resource scaling for Snakemake jobs across the Cactus pipelines. `rule_resources` entries can now be specified as either a single value or a per-attempt YAML list, so failed jobs can be automatically resubmitted with larger _mem_mb_, longer time, or other updated rule resources when Snakemake is run with `--retries`.

The implementation is centralized in the shared resource helper, so existing scalar configs remain fully backward-compatible and all pipelines that use `getRuleResources()` inherit the feature. The config templates were also updated to document the new syntax and its requirement for Snakemake retries.